### PR TITLE
ensure that DateTime.Round returns a date with the same Kind as input

### DIFF
--- a/SGP.NET/Util/TimeExtensions.cs
+++ b/SGP.NET/Util/TimeExtensions.cs
@@ -58,7 +58,7 @@ namespace SGPdotNET.Util
         internal static DateTime Round(this DateTime date, TimeSpan span)
         {
             var ticks = (date.Ticks + span.Ticks / 2 + 1) / span.Ticks;
-            return new DateTime(ticks * span.Ticks);
+            return new DateTime(ticks * span.Ticks, date.Kind);
         }
     }
 }


### PR DESCRIPTION
… DateTime

I think this change is a part of the fix to #9, otherwise a DateTime with an Undefined Kind are returned by Round. It's sufficient if UTC DateTimes are always passed in. The other (larger) part of the solution is your `ToStrictUtc()` check to deal with when they aren't.