### PR TITLE
Add NET Standard 2.0 build target

### DIFF
--- a/SGP.NET/CoordinateSystem/Coordinate.cs
+++ b/SGP.NET/CoordinateSystem/Coordinate.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using SGPdotNET.Observation;
-using SGPdotNET.Propogation;
+using SGPdotNET.Propagation;
 using SGPdotNET.Util;
 
 namespace SGPdotNET.CoordinateSystem

--- a/SGP.NET/CoordinateSystem/EciCoordinate.cs
+++ b/SGP.NET/CoordinateSystem/EciCoordinate.cs
@@ -1,5 +1,5 @@
 using System;
-using SGPdotNET.Propogation;
+using SGPdotNET.Propagation;
 using SGPdotNET.Util;
 
 namespace SGPdotNET.CoordinateSystem

--- a/SGP.NET/CoordinateSystem/GeodeticCoordinate.cs
+++ b/SGP.NET/CoordinateSystem/GeodeticCoordinate.cs
@@ -1,5 +1,5 @@
 using System;
-using SGPdotNET.Propogation;
+using SGPdotNET.Propagation;
 using SGPdotNET.Util;
 
 namespace SGPdotNET.CoordinateSystem

--- a/SGP.NET/Observation/Satellite.cs
+++ b/SGP.NET/Observation/Satellite.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using SGPdotNET.CoordinateSystem;
-using SGPdotNET.Propogation;
+using SGPdotNET.Propagation;
 using SGPdotNET.TLE;
 using SGPdotNET.Util;
 

--- a/SGP.NET/Observation/TopocentricObservation.cs
+++ b/SGP.NET/Observation/TopocentricObservation.cs
@@ -1,6 +1,6 @@
 using System;
 using SGPdotNET.CoordinateSystem;
-using SGPdotNET.Propogation;
+using SGPdotNET.Propagation;
 using SGPdotNET.Util;
 
 namespace SGPdotNET.Observation

--- a/SGP.NET/Propagation/Orbit.cs
+++ b/SGP.NET/Propagation/Orbit.cs
@@ -2,7 +2,7 @@ using System;
 using SGPdotNET.TLE;
 using SGPdotNET.Util;
 
-namespace SGPdotNET.Propogation
+namespace SGPdotNET.Propagation
 {
     /// <summary>
     ///     Container for the extracted orbital elements used by the SGP4 propagator.

--- a/SGP.NET/Propagation/SGP4.cs
+++ b/SGP.NET/Propagation/SGP4.cs
@@ -4,7 +4,7 @@ using SGPdotNET.Exception;
 using SGPdotNET.TLE;
 using SGPdotNET.Util;
 
-namespace SGPdotNET.Propogation
+namespace SGPdotNET.Propagation
 {
     /// <summary>
     ///     The Simplified General Perturbations (Model 4) propagater

--- a/SGP.NET/Propagation/SgpConstants.cs
+++ b/SGP.NET/Propagation/SgpConstants.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace SGPdotNET.Propogation
+namespace SGPdotNET.Propagation
 {
     /// <summary>
     ///     Stores various numerical constants used in propogation

--- a/SGP.NET/SGP.NET.csproj
+++ b/SGP.NET/SGP.NET.csproj
@@ -13,7 +13,7 @@
     <Copyright>Copyright 2019</Copyright>
     <PackageTags>satellite orbit tracking prediction observation sgp4</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb;.xml</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <Description>C# SGP4 Satellite Prediction Library. Multi-function library with support for loading satellites from TLEs, converting between coordinate systems and reference frames, observing satellites from ground stations, and creating schedules of observations over periods of time.</Description>
     <GenerateDocumentationFile Condition="'$(Configuration)'=='Release'">true</GenerateDocumentationFile>
     <RootNamespace>SGPdotNET</RootNamespace>

--- a/SGP.NET/SGP.NET.csproj
+++ b/SGP.NET/SGP.NET.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/1.6.68">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.4</TargetFrameworks>
+    <TargetFrameworks>netstandard1.4;netstandard2.0</TargetFrameworks>
     <PackageId>SGP.NET</PackageId>
-    <Version>1.1.1</Version>
+    <Version>1.2.0</Version>
     <Authors>parzivail</Authors>
     <Company>parzivail</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -17,16 +17,16 @@
     <Description>C# SGP4 Satellite Prediction Library. Multi-function library with support for loading satellites from TLEs, converting between coordinate systems and reference frames, observing satellites from ground stations, and creating schedules of observations over periods of time.</Description>
     <GenerateDocumentationFile Condition="'$(Configuration)'=='Release'">true</GenerateDocumentationFile>
     <RootNamespace>SGPdotNET</RootNamespace>
-    <PackageReleaseNotes>Fixed #17, where FindNextBelowToAboveCrossingPoint could potentially return a time for which the elevation of the observer is below minElevation if no such crossing point exists between the start and end times provided</PackageReleaseNotes>
-    <AssemblyVersion>1.1.1.0</AssemblyVersion>
-    <FileVersion>1.1.1.0</FileVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.4|AnyCPU'">
-    <DocumentationFile>obj\Debug\netstandard1.4\SGP.NET.xml</DocumentationFile>
+    <PackageReleaseNotes>Added netstandard2.0 target</PackageReleaseNotes>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.4|AnyCPU'">
     <DocumentationFile>obj\Release\netstandard1.4\SGP.NET.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
+    <DocumentationFile>obj\Release\netstandard2.0\SGP.NET.xml</DocumentationFile>
   </PropertyGroup>
 </Project>

--- a/SGP.NET/Util/MathUtil.cs
+++ b/SGP.NET/Util/MathUtil.cs
@@ -1,5 +1,5 @@
 using System;
-using SGPdotNET.Propogation;
+using SGPdotNET.Propagation;
 
 namespace SGPdotNET.Util
 {


### PR DESCRIPTION
I added a `netstandard2.0` target framework.

The NuGet package should continue to function as normal for `netstandard1.4` users - there's just a new `lib/netstandard2.0` folder included.

I also added the XML documentation to the NuGet package, so users who download and install it will have all of the docs included.

Let me know if you have any questions or would like any changes!