### PR TITLE
fix small defects

### DIFF
--- a/SGP.NET/Observation/GroundStation.cs
+++ b/SGP.NET/Observation/GroundStation.cs
@@ -100,7 +100,13 @@ namespace SGPdotNET.Observation
 					maxElTime = tu.MaxElevationTime;
 				}
 
-				var before = maxElTime - deltaTime;
+        if (maxElTime == DateTime.MinValue)
+        {
+          t = losTime + deltaTime;
+          continue;
+        }
+
+        var before = maxElTime - deltaTime;
 
 				if (clipToStartTime) // ensure before is clipped for max elevation search 
 				{
@@ -122,8 +128,8 @@ namespace SGPdotNET.Observation
 				t = losTime + deltaTime;
 			} while (t <= end);
 
-			// if clipToStartTime is false and the start time has been clipped, walk back in time until previous AOS crossing point has been found
-			if (!clipToStartTime && obs.Count > 0 && obs[0].Start == start)
+      // if clipToStartTime is false and the start time has been clipped, walk back in time until previous AOS crossing point has been found
+      if (!clipToStartTime && obs.Count > 0 && obs[0].Start <= start)
 			{
 				var first = obs[0];
 				var tu = FindNextAboveToBelowCrossingPoint(satellite, first.Start, deltaTime.Negate(), minElevation, resolution);


### PR DESCRIPTION
The first change handles the case when `maxElTime` is not found.

The second change is needed because `obs[0].Start`, computed in `FindCrossingTimeWithinInterval`, is between `start-deltaTime` and` start`, it is not exactly equal to `start`, so the `if` condition in the original code always evaluates to false. Changing the comparison to `<=` fixes the problem.