### PR TITLE
Make DeepSpaceSecular parameters `ref`

### DIFF
--- a/SGP.NET/Propagation/SGP4.cs
+++ b/SGP.NET/Propagation/SGP4.cs
@@ -250,7 +250,7 @@ public class Sgp4
         var e = Orbit.Eccentricity;
         var xincl = Orbit.Inclination;
 
-        DeepSpaceSecular(tsince, ref xmdf, omgadf, xnode, ref e, ref xincl, ref xn);
+        DeepSpaceSecular(tsince, ref xmdf, ref omgadf, ref xnode, ref e, ref xincl, ref xn);
 
         if (xn <= 0.0)
             throw new SatellitePropagationException("Error: (xn <= 0.0)");
@@ -1114,7 +1114,7 @@ public class Sgp4
         }
     }
 
-    private void DeepSpaceSecular(double tsince, ref double xll, double omgasm, double xnodes, ref double em,
+    private void DeepSpaceSecular(double tsince, ref double xll, ref double omgasm, ref double xnodes, ref double em,
         ref Angle xinc, ref double xn)
     {
         const double step = 720.0;


### PR DESCRIPTION
It seems when 0ced2b7b2e63db3532e6339bf8d8dced14a17698 made `omgasm` `xnodes` `ref` parameters for `DeepSpacePeriodics`'s it missed `DeepSpaceSecular`?

The changed code aligns with
https://github.com/dnwrnr/sgp4/blob/661e057a5d369d5ee424676cf1d69cbead95ff2c/libsgp4/SGP4.cc#L1234-L1238
and
https://github.com/OpenATS/OpenATS/blob/master/server/deep.c#L567-L571